### PR TITLE
Fix appveyor fail

### DIFF
--- a/src/AspNetCore.LegacyAuthCookieCompat.Tests/TestHelper.cs
+++ b/src/AspNetCore.LegacyAuthCookieCompat.Tests/TestHelper.cs
@@ -8,7 +8,7 @@ namespace AspNetCore.LegacyAuthCookieCompat.Tests
 	{
 		public static bool IsValid(this FormsAuthenticationTicket ticket)
 		{
-			return ticket.IssueDate < DateTime.Now && !ticket.Expired;
+			return ticket.IssueDate <= DateTime.Now && !ticket.Expired;
 		}
 	}
 }


### PR DESCRIPTION
Here is the fix for the appveyor tests following #22 

I can't reproduce it either...
Here is what I gathered from it:

The error is at line 63, therefore the failing test is
`Assert.AreEqual(true, decryptedFormsAuthenticationTicket.IsValid());` This matches the error message as well.

Since line 62 passes, `decryptedFormsAuthenticationTicket.Expired` must be `false`.
Therefore the failing test must be `ticket.IssueDate < DateTime.Now`

`IssueDate` is originally generated as `DateTime.UtcNow.ToLocalTime()`.
All the other tests have identical tests.
If it was something related to timezones and `ticket.IssueDate > DateTime.Now`, all the other tests would fail as well.

I've tried locally and using UTC-4, UTC, UTC+1 and UTC+12 timezones and was unable to reproduce the issue. That goes further toward the issue being independent from timezones.

I think the only possibility would be that `ticket.IssueDate == DateTime.Now` because of some JIT optimization or other system load related variable.